### PR TITLE
inform tree-sitter of zig file type

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,4 +16,14 @@
   "scripts": {
     "test": "tree-sitter test"
   }
+  ,
+  "tree-sitter": [
+    {
+      "scope": "source.zig",
+      "injection-regex": "zig",
+      "file-types": [
+        "zig"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This adds the metadata to package.json for tree-sitter to autodetect when this is the correct grammar for a file.