### PR TITLE
Include leading \\ characters as anonymous nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -118,8 +118,7 @@ const AMPERSAND = "&",
   dec_int = seq(dec, repeat(dec_)),
   hex_int = seq(hex, repeat(hex_)),
   unescaped_string_fragment = token.immediate(prec(1, /[^"\\\{\}]+/)),
-  unescaped_char_fragment = token.immediate(prec(1, /[^'\\]/)),
-  line_string = token(seq("\\\\", /[^\n]*/));
+  unescaped_char_fragment = token.immediate(prec(1, /[^'\\]/));
 
 module.exports = grammar({
   name: "zig",
@@ -843,9 +842,9 @@ module.exports = grammar({
         '"'
       ),
 
-    LINESTRING: (_) => repeat1(line_string),
+    LINESTRING: (_) => seq("\\\\", /[^\n]*/),
 
-    _STRINGLITERAL: ($) => choice($.STRINGLITERALSINGLE, $.LINESTRING),
+    _STRINGLITERAL: ($) => choice($.STRINGLITERALSINGLE, repeat1($.LINESTRING)),
 
     Variable: ($) => field("variable", $.IDENTIFIER),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5288,23 +5288,17 @@
       ]
     },
     "LINESTRING": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "TOKEN",
-        "content": {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "\\\\"
-            },
-            {
-              "type": "PATTERN",
-              "value": "[^\\n]*"
-            }
-          ]
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\\\"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[^\\n]*"
         }
-      }
+      ]
     },
     "_STRINGLITERAL": {
       "type": "CHOICE",
@@ -5314,8 +5308,11 @@
           "name": "STRINGLITERALSINGLE"
         },
         {
-          "type": "SYMBOL",
-          "name": "LINESTRING"
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "LINESTRING"
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3322,6 +3322,10 @@
     "named": false
   },
   {
+    "type": "\\\\",
+    "named": false
+  },
+  {
     "type": "]",
     "named": false
   },

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Include the leading `\\` characters for multiline strings as anonymous
nodes in the parsed tree. This allows highlighters to highlight these
characters separately from the rest of the string.

The motivation for this is that it is useful to highlight the leading `\\`
characters differently than the actual string. This is *especially* useful if
the string contains `\` characters itself, as it makes it much easier to see
those characters at a quick glance.

Note that this changes how the `LINESTRING` nodes appear in the syntax tree.
Consider the following source code:

```zig
const std = @import("std");

const message =
    \\Hello, world!
    \\This is my multi-
    \\line message. I hope
    \\you like it.
    \\
;

pub fn main() !void {
    std.debug.print(message, .{});
}
```

**Before:**

```
(TopLevelDecl) [3:1-9:1]
  (VarDecl) [3:1-9:1]
    "const" [3:1-5]
    variable_type_function: (IDENTIFIER) [3:7-13]
    "=" [3:15-15]
    (ErrorUnionExpr) [4:5-8:6]
      (SuffixExpr) [4:5-8:6]
        (LINESTRING) [4:5-8:6]
    ";" [9:1-1]
```

**After:**

```
(TopLevelDecl) [3:1-9:1]
  (VarDecl) [3:1-9:1]
    "const" [3:1-5]
    variable_type_function: (IDENTIFIER) [3:7-13]
    "=" [3:15-15]
    (ErrorUnionExpr) [4:5-8:6]
      (SuffixExpr) [4:5-8:6]
        (LINESTRING) [4:5-20]
          "\\" [4:5-6]
        (LINESTRING) [5:5-24]
          "\\" [5:5-6]
        (LINESTRING) [6:5-27]
          "\\" [6:5-6]
        (LINESTRING) [7:5-19]
          "\\" [7:5-6]
        (LINESTRING) [8:5-6]
          "\\" [8:5-6]
    ";" [9:1-1]
```

However, I think this should be backward compatible with existing queries.