### PR TITLE
Add support for SwiftPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterZig",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterZig", targets: ["TreeSitterZig"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterZig",
+                path: ".",
+                exclude: [
+                    "assets",
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.lock",
+                    "Cargo.toml",
+                    "grammar.js",
+                    "grammar.y",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterZig/zig.h
+++ b/bindings/swift/TreeSitterZig/zig.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_ZIG_H_
+#define TREE_SITTER_ZIG_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_zig();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ZIG_H_


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.

Related:
- https://github.com/tree-sitter/tree-sitter-bash/pull/124
- https://github.com/tree-sitter/tree-sitter-c/pull/105
- https://github.com/tree-sitter/tree-sitter-cpp/pull/160
- https://github.com/tree-sitter/tree-sitter-c-sharp/pull/227
- https://github.com/tree-sitter/tree-sitter-css/pull/27
- https://github.com/tree-sitter/tree-sitter-go/pull/79
- https://github.com/tree-sitter/tree-sitter-html/pull/39
- https://github.com/tree-sitter/tree-sitter-java/pull/113
- https://github.com/tree-sitter/tree-sitter-javascript/pull/223
- https://github.com/tree-sitter/tree-sitter-json/pull/27