### PR TITLE
Remove token.immediate from format and escape sequence rules

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -799,33 +799,29 @@ module.exports = grammar({
       ),
 
     EscapeSequence: (_) =>
-      token.immediate(
-        choice(
-          seq(
-            "\\",
-            choice(/x[0-9a-fA-f]{2}/, /u\{[0-9a-fA-F]+\}/, /[nr\\t'"]/)
-          ),
-          "{{",
-          "}}"
-        )
+      choice(
+        seq(
+          "\\",
+          choice(/x[0-9a-fA-f]{2}/, /u\{[0-9a-fA-F]+\}/, /[nr\\t'"]/)
+        ),
+        "{{",
+        "}}"
       ),
 
     FormatSequence: (_) =>
-      token.immediate(
-        seq(
-          "{",
-          /[0-9]*/,
-          optional(choice(/[xXsedbocu*]{1}/, "any")),
-          optional(
-            seq(
-              ":",
-              optional(seq(/[^"\\\{\}]{1}/, /[<^>]{1}/, /[0-9]+/)),
-              /.{0,1}/,
-              /[0-9]*/
-            )
-          ),
-          "}"
-        )
+      seq(
+        "{",
+        /[0-9]*/,
+        optional(choice(/[xXsedbocu*]{1}/, "any")),
+        optional(
+          seq(
+            ":",
+            optional(seq(/[^"\\\{\}]{1}/, /[<^>]{1}/, /[0-9]+/)),
+            /.{0,1}/,
+            /[0-9]*/
+          )
+        ),
+        "}"
       ),
 
     STRINGLITERALSINGLE: ($) =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5099,137 +5099,131 @@
       ]
     },
     "EscapeSequence": {
-      "type": "IMMEDIATE_TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "\\"
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "x[0-9a-fA-f]{2}"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "u\\{[0-9a-fA-F]+\\}"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[nr\\\\t'\"]"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "{{"
-          },
-          {
-            "type": "STRING",
-            "value": "}}"
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\\"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "x[0-9a-fA-f]{2}"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "u\\{[0-9a-fA-F]+\\}"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[nr\\\\t'\"]"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "{{"
+        },
+        {
+          "type": "STRING",
+          "value": "}}"
+        }
+      ]
     },
     "FormatSequence": {
-      "type": "IMMEDIATE_TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "{"
-          },
-          {
-            "type": "PATTERN",
-            "value": "[0-9]*"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "PATTERN",
-                    "value": "[xXsedbocu*]{1}"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "any"
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ":"
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\"\\\\\\{\\}]{1}"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[<^>]{1}"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[0-9]+"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": ".{0,1}"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[0-9]*"
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "}"
-          }
-        ]
-      }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[0-9]*"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "PATTERN",
+                  "value": "[xXsedbocu*]{1}"
+                },
+                {
+                  "type": "STRING",
+                  "value": "any"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ":"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "PATTERN",
+                          "value": "[^\"\\\\\\{\\}]{1}"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "[<^>]{1}"
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "[0-9]+"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "PATTERN",
+                  "value": ".{0,1}"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[0-9]*"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
     },
     "STRINGLITERALSINGLE": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1006,6 +1006,11 @@
     }
   },
   {
+    "type": "EscapeSequence",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "FLOAT",
     "named": true,
     "fields": {}
@@ -1402,6 +1407,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "FormatSequence",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "GroupedExpr",
@@ -3310,15 +3320,11 @@
     "named": true
   },
   {
-    "type": "EscapeSequence",
-    "named": true
-  },
-  {
-    "type": "FormatSequence",
-    "named": true
-  },
-  {
     "type": "[",
+    "named": false
+  },
+  {
+    "type": "\\",
     "named": false
   },
   {
@@ -3347,6 +3353,10 @@
   },
   {
     "type": "and",
+    "named": false
+  },
+  {
+    "type": "any",
     "named": false
   },
   {
@@ -3566,6 +3576,10 @@
     "named": false
   },
   {
+    "type": "{{",
+    "named": false
+  },
+  {
     "type": "|",
     "named": false
   },
@@ -3579,6 +3593,10 @@
   },
   {
     "type": "}",
+    "named": false
+  },
+  {
+    "type": "}}",
     "named": false
   },
   {


### PR DESCRIPTION
`token.immediate` ties together the parsed sequence into a single opaque node, making it impossible to query for the `{`/`}` tokens. `token.immediate` appears to have no effect on format or escape sequence parsing and can be removed.