### PR TITLE
Bring keywords in line with official TreeSitter guidelines

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -88,107 +88,60 @@ field_constant: (IDENTIFIER) @constant
 (EscapeSequence) @string.escape
 (FormatSequence) @string.special
 
-[
-  "allowzero"
-  "volatile"
-  "anytype"
-  "anyframe"
-  (BuildinTypeExpr)
-] @type.builtin
-
 (BreakLabel (IDENTIFIER) @label)
 (BlockLabel (IDENTIFIER) @label)
 
 [
-  "true"
-  "false"
-] @boolean
-
-[
-  "undefined"
-  "unreachable"
-  "null"
-] @constant.builtin
-
-[
-  "else"
-  "if"
-  "switch"
-] @conditional
-
-[
-  "for"
-  "while"
-] @repeat
-
-[
-  "or"
+  "addrspace"
+  "align"
+  "allowzero"
   "and"
-  "orelse"
-] @keyword.operator
-
-[
-  "struct"
-  "enum"
-  "union"
-  "error"
-  "packed"
-  "opaque"
-] @keyword
-
-[
-  "try"
-  "error"
-  "catch"
-] @exception
-
-; VarDecl
-[
-  "const"
-  "var"
-  "comptime"
-  "threadlocal"
-  "fn"
-] @keyword.function
-
-[
-  "test"
-  "pub"
-  "usingnamespace"
-] @keyword
-
-[
-  "return"
-  "break"
-  "continue"
-] @keyword.return
-
-; Macro
-[
-  "defer"
-  "errdefer"
+  "anyframe"
+  "anytype"
+  "asm"
   "async"
-  "nosuspend"
   "await"
-  "suspend"
-  "resume"
+  "break"
+  "callconv"
+  "catch"
+  "comptime"
+  "const"
+  "continue"
+  "defer"
+  "else"
+  "enum"
+  "errdefer"
+  "error"
   "export"
   "extern"
-] @function.macro
-
-; PrecProc
-[
+  "fn"
+  "for"
+  "if"
   "inline"
-  "noinline"
-  "asm"
-  "callconv"
   "noalias"
-] @attribute
-
-[
+  "nosuspend"
+  "noinline"
+  "opaque"
+  "or"
+  "orelse"
+  "packed"
+  "pub"
+  "resume"
+  "return"
   "linksection"
-  "align" 
-] @function.builtin
+  "struct"
+  "suspend"
+  "switch"
+  "test"
+  "threadlocal"
+  "try"
+  "union"
+  "unreachable"
+  "usingnamespace"
+  "var"
+  "volatile"
+  "while"
+] @keyword
 
 [
   (CompareOp)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -92,56 +92,104 @@ field_constant: (IDENTIFIER) @constant
 (BlockLabel (IDENTIFIER) @label)
 
 [
-  "addrspace"
-  "align"
-  "allowzero"
-  "and"
-  "anyframe"
-  "anytype"
   "asm"
   "async"
   "await"
-  "break"
-  "callconv"
-  "catch"
-  "comptime"
-  "const"
-  "continue"
   "defer"
-  "else"
-  "enum"
   "errdefer"
-  "error"
-  "export"
-  "extern"
-  "fn"
-  "for"
-  "if"
-  "inline"
-  "noalias"
   "nosuspend"
-  "noinline"
-  "opaque"
+  "resume"
+  "suspend"
+  "test"
+] @keyword
+
+[
+  "fn"
+] @keyword.function
+
+[
+  "and"
   "or"
   "orelse"
-  "packed"
-  "pub"
-  "resume"
+] @keyword.operator
+
+[
   "return"
-  "linksection"
-  "struct"
-  "suspend"
+  "break"
+  "continue"
+] @keyword.return
+
+[
+  "if"
+  "else"
   "switch"
-  "test"
-  "threadlocal"
-  "try"
-  "union"
-  "unreachable"
+] @conditional
+
+[
+  "for"
+  "while"
+] @repeat
+
+[
   "usingnamespace"
+] @include
+
+[
+  "try"
+  "catch"
+] @exception
+
+[
+  "void"
+  "noreturn"
+  "anytype"
+  "anyframe"
+  "anyopaque"
+  "anyerror"
+  (BuildinTypeExpr)
+] @type.builtin
+
+[
+  "struct"
+  "union"
+  "enum"
+  "opaque"
+  "error"
+] @type.definition
+
+[
+  "const"
   "var"
   "volatile"
-  "while"
-] @keyword
+  "allowzero"
+  "noalias"
+] @type.qualifier
+
+[
+  "addrspace"
+  "align"
+  "callconv"
+  "linksection"
+] @storageclass
+
+[
+  "comptime"
+  "export"
+  "extern"
+  "inline"
+  "noinline"
+  "packed"
+  "pub"
+  "threadlocal"
+] @attribute
+
+[
+  "null"
+  "unreachable"
+  "undefined"
+  "true"
+  "false"
+] @constant.builtin
 
 [
   (CompareOp)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -93,13 +93,9 @@ field_constant: (IDENTIFIER) @constant
 
 [
   "asm"
-  "async"
-  "await"
   "defer"
   "errdefer"
   "nosuspend"
-  "resume"
-  "suspend"
   "test"
 ] @keyword
 
@@ -117,6 +113,10 @@ field_constant: (IDENTIFIER) @constant
   "return"
   "break"
   "continue"
+  "async"
+  "await"
+  "suspend"
+  "resume"
 ] @keyword.return
 
 [

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -140,12 +140,7 @@ field_constant: (IDENTIFIER) @constant
 ] @exception
 
 [
-  "void"
-  "noreturn"
   "anytype"
-  "anyframe"
-  "anyopaque"
-  "anyerror"
   (BuildinTypeExpr)
 ] @type.builtin
 


### PR DESCRIPTION
This PR brings in all keywords in the official Zig grammar, and categorises them according to [official TreeSitter guidelines](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md#keywords). I had found some inconsistencies and miscategorisations in the standing grammar. 