### PR TITLE
Add ignored files to .gitignore + commit package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target
 *.o
 /bindings/c/*.h
 /bindings/c/tree-sitter-*.pc
+/build
+/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "tree-sitter-zig",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-zig",
+      "version": "0.0.1",
+      "dependencies": {
+        "nan": "^2.12.1"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.20.1"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
+      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "tree-sitter": "cli.js"
+      }
+    }
+  },
+  "dependencies": {
+    "nan": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+    },
+    "tree-sitter-cli": {
+      "version": "0.20.7",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.20.7.tgz",
+      "integrity": "sha512-MHABT8oCPr4D0fatsPo6ATQ9H4h9vHpPRjlxkxJs80tpfAEKGn6A1zU3eqfCKBcgmfZDe9CiL3rKOGMzYHwA3w==",
+      "dev": true
+    }
+  }
+}


### PR DESCRIPTION
- `package-lock.json` is useful for reproducible builds when doing `npm install`
- `build` and `node_modules` are generated while compiling the grammar, so they should be ignored