### PR TITLE
Fix parsing for Sentinel-Terminated Exprs

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -383,15 +383,13 @@ module.exports = grammar({
                     optional(keyword("async", $)),
                     choice(
                         $._PrimaryTypeExpr,
-                        seq($._PrimaryTypeExpr, $.FnCallArguments),
                         field("variable_type_function", $.IDENTIFIER),
-                        seq(field("function_call", $.IDENTIFIER), $.FnCallArguments)
                     ),
                     repeat(
                         choice(
                             $.SuffixOp,
-                            seq($.SuffixOp, $.FnCallArguments),
-                            $.FieldOrFnCall
+                            $.FieldOrFnCall,
+                            $.FnCallArguments,
                         )
                     )
                 )

--- a/scripts/known-parsing-failures.txt
+++ b/scripts/known-parsing-failures.txt
@@ -7,8 +7,6 @@ zig/test/behavior/slice_sentinel_comptime.zig
 zig/test/behavior/bugs/12972.zig
 zig/test/behavior/packed_struct_explicit_backing_int.zig
 zig/lib/std/os.zig
-zig/lib/std/array_hash_map.zig
-zig/lib/std/hash/auto_hash.zig
 zig/lib/std/fs.zig
 zig/lib/std/mem.zig
 zig/lib/std/zig/c_translation.zig
@@ -25,7 +23,6 @@ zig/lib/std/os/uefi/protocols/absolute_pointer_protocol.zig
 zig/lib/std/os/uefi/protocols/edid_override_protocol.zig
 zig/lib/std/os/uefi/tables/boot_services.zig
 zig/lib/std/unicode.zig
-zig/lib/std/meta/trait.zig
 zig/lib/std/Thread.zig
 zig/lib/std/mem/Allocator.zig
 zig/lib/std/json/test.zig
@@ -35,7 +32,6 @@ zig/lib/std/process.zig
 zig/lib/std/dwarf.zig
 zig/lib/std/json.zig
 zig/lib/std/c/openbsd.zig
-zig/lib/std/meta.zig
 zig/src/main.zig
 zig/src/link/Wasm/Object.zig
 zig/src/link/Wasm/Archive.zig
@@ -44,4 +40,3 @@ zig/src/Air.zig
 zig/src/codegen/llvm/bindings.zig
 zig/src/Autodoc.zig
 zig/src/Zir.zig
-zig/tools/process_headers.zig

--- a/scripts/known-parsing-failures.txt
+++ b/scripts/known-parsing-failures.txt
@@ -1,4 +1,3 @@
-zig/test/cases/safety/slice with sentinel out of bounds - runtime len.zig
 zig/test/behavior/struct.zig
 zig/test/behavior/slice.zig
 zig/test/behavior/array.zig
@@ -10,7 +9,6 @@ zig/lib/std/os.zig
 zig/lib/std/fs.zig
 zig/lib/std/mem.zig
 zig/lib/std/zig/c_translation.zig
-zig/lib/std/zig/system/windows.zig
 zig/lib/std/os/test.zig
 zig/lib/std/os/linux/bpf/btf.zig
 zig/lib/std/os/linux/bpf.zig
@@ -24,19 +22,11 @@ zig/lib/std/os/uefi/protocols/edid_override_protocol.zig
 zig/lib/std/os/uefi/tables/boot_services.zig
 zig/lib/std/unicode.zig
 zig/lib/std/Thread.zig
-zig/lib/std/mem/Allocator.zig
 zig/lib/std/json/test.zig
-zig/lib/std/child_process.zig
 zig/lib/std/macho.zig
-zig/lib/std/process.zig
-zig/lib/std/dwarf.zig
-zig/lib/std/json.zig
 zig/lib/std/c/openbsd.zig
-zig/src/main.zig
 zig/src/link/Wasm/Object.zig
 zig/src/link/Wasm/Archive.zig
 zig/src/link/MachO/Archive.zig
-zig/src/Air.zig
 zig/src/codegen/llvm/bindings.zig
 zig/src/Autodoc.zig
-zig/src/Zir.zig

--- a/scripts/test-parsing
+++ b/scripts/test-parsing
@@ -84,7 +84,8 @@ if [ ${#parse_args[*]} -eq 0 ]; then
   exit 1
 fi
 
-echo "[STEP] The following files will be tested:"
-printf "%s\n" "${parse_args[@]}"
+echo $'\n'"The following files will be tested:"
+printf -- "- %s\n" "${parse_args[@]}"
+echo $'\n'
 
 tree-sitter parse -q "${parse_args[@]}"

--- a/scripts/test-parsing
+++ b/scripts/test-parsing
@@ -84,7 +84,7 @@ if [ ${#parse_args[*]} -eq 0 ]; then
   exit 1
 fi
 
-echo $'\n'"The following files will be tested:"
+echo $'\n'"The following files will be parsed:"
 printf -- "- %s\n" "${parse_args[@]}"
 echo $'\n'
 


### PR DESCRIPTION
close #31 

This PR builds upon the changes of https://github.com/maxxnino/tree-sitter-zig/pull/30 for convenience's sake. The changes unique to this PR start from commit ac15348998e9bc8be7f3afe09286eaaf4d2c81d4. Let me know if you'd like to have them separate.