### PR TITLE
gitattributes: Mark images as binary so they don't get modified

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text eol=lf
+*.png binary
 
 src/*.json linguist-generated
 src/parser.c linguist-generated


### PR DESCRIPTION
I noticed on macOS that the png files always show as modified; this prevents that from happening.